### PR TITLE
avoid N+1 query by eager loading

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::CardsController < ApplicationController
 
     def index
-        cards = Card.all
+        cards = Card.with_attached_main_image
         render json: CardSerializer.new(cards)
     end
 

--- a/app/controllers/api/v1/relics_controller.rb
+++ b/app/controllers/api/v1/relics_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::RelicsController < ApplicationController
 
     def index
-        relics = Relic.all
+        relics = Relic.with_attached_main_image
         render json: RelicSerializer.new(relics)
     end
 

--- a/app/serializers/card_serializer.rb
+++ b/app/serializers/card_serializer.rb
@@ -1,7 +1,11 @@
 class CardSerializer
   include FastJsonapi::ObjectSerializer
+
   attributes :name, :color, :rarity, :card_type, :cost, :description
-  attribute :image do |object| 
-    Rails.application.routes.url_helpers.rails_blob_url(object.main_image) if object.main_image.attached?
+
+  attribute :image do |object|
+    if object.main_image.attached?
+      Rails.application.routes.url_helpers.rails_blob_url(object.main_image)
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,13 +42,20 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  config.log_level = :debug
+  config.log_tags = [ :request_id ]
+
+  logger           = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger    = ActiveSupport::TaggedLogging.new(logger)
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # see https://stackoverflow.com/a/38239345/198348
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end
 
 Rails.application.routes.default_url_options[:host] = 'localhost:3000'


### PR DESCRIPTION
also added logging during development

For more details on N+1:

- https://stackoverflow.com/questions/57357892/rails-reducing-the-amount-of-activestorage-queries
- https://api.rubyonrails.org/classes/ActiveStorage/Attached/Model.html#method-i-has_one_attached

This fixes jhcheung/slay-the-spire-library-react#6